### PR TITLE
Update extraChunks to use stack instead of recursion.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,14 +15,26 @@ class HashCachePlugin {
   }
 
   static extractChunks(chunkGroups) {
-    return chunkGroups.reduce(
-      (memo, chunkGroup) =>
-        memo.concat(
-          chunkGroup.chunks,
-          HashCachePlugin.extractChunks(chunkGroup.getChildren())
-        ),
-      []
-    )
+    let result = [];
+    const seenChunks = {};
+    const stack = chunkGroups.slice();
+
+    while (stack.length > 0) {
+      const chunkGroup = stack.pop();
+      result = result.concat(chunkGroup.chunks);
+      // eslint-disable-next-line no-param-reassign
+      seenChunks[chunkGroup.groupDebugId] = true;
+      const chunkChildren = chunkGroup.getChildren();
+
+      chunkChildren.forEach((childChunkGroup) => {
+        const isNewChunk = !seenChunks[childChunkGroup.groupDebugId];
+        if (isNewChunk) {
+          stack.push(childChunkGroup);
+        }
+      });
+    }
+
+    return result;
   }
 
   static statsEntryHelper(stats) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-hash-cache",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "An experimental incremental build plugin for Webpack.",
   "main": "lib/index.js",
   "author": "cfruit <cfruit@cargurus.com>",


### PR DESCRIPTION
In order to get around 'Maximum call stack size reached' error.